### PR TITLE
Added conditional HTML tag, HTML5 Shiv, and Respond.js scripts

### DIFF
--- a/JoanneYahn_CodeChallenge4.html
+++ b/JoanneYahn_CodeChallenge4.html
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
-<html class="ie8 ie_old" lang="en">
+ <!--[if IE 8]> <html class="ie8 ie_old" lang="en"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en"> <!--<![endif]-->
 
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1"/>
 	<title>Code Challenge 4</title>
 	  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
-	  <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-	<script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
-    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+	  <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
 </head>
 
 <body>


### PR DESCRIPTION
The comment characters around the HTML5 Shiv, Respond.js and the wrapping HTML tag are to be retained whenever you add these to the document. This ensures that the code is only rendered when the conditions stated are met. For instance, in the code below, the part that reads <!--[if lt IE 9]> means that if the browser detected is less than Internet Explorer 9, then the scripts will be loaded. If the IE version is greater than IE9, the scripts will not render.

<!--[if lt IE 9]>
      <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
    <![endif]-->
